### PR TITLE
Fixed two gcc warnings under MacOSX

### DIFF
--- a/MacOSX/input.c
+++ b/MacOSX/input.c
@@ -402,7 +402,7 @@ char* close_parens( char* start, char* end )
             stack++;
     }
     
-    printf( "\nThe expression '%.*s' has an unmatched parenthesis.\nQuitting\n\n", end - start, start );
+    printf( "\nThe expression '%.*s' has an unmatched parenthesis.\nQuitting\n\n", (int) (end - start), start );
     exit( EXIT_FAILURE );
 }
 
@@ -410,10 +410,10 @@ char* close_parens( char* start, char* end )
 /* Trim whitespace from both ends of a string bounded by '*start' and '*end' */
 void trim( char** start, char** end )
 {
-    for ( ; *start < *end; *start++ )
+    for ( ; *start < *end; start++ )
         if ( !isspace( (int) **start ) )
             break;
-    for ( ; *start < *end; *end-- )
+    for ( ; *start < *end; end-- )
         if ( !isspace( (int) *( *end - 1 ) ) )
             break;
 }


### PR DESCRIPTION
## Problem

GCC gives some Warnings when compiling the MacOSX version, here's how to reproduce:

``` bash
$ make
gcc -Wall -g    -c -o input.o input.c
input.c:405:34: warning: field precision should have type 'int', but argument has type 'long' [-Wformat]
    printf( "\nThe expression '%.*s' has an unmatched parenthesis.\nQuitting\n\n", end - start, start );
                               ~~^~                                                ~~~~~~~~~~~
input.c:413:28: warning: expression result unused [-Wunused-value]
    for ( ; *start < *end; *start++ )
                           ^~~~~~~~
input.c:416:28: warning: expression result unused [-Wunused-value]
    for ( ; *start < *end; *end-- )
                           ^~~~~~
3 warnings generated.
# gcc -Wall -g -static -o tsl main.o input.o output.o debug.o
gcc -Wall -g -o tsl main.o input.o output.o debug.o
```

My GCC version:

``` bash
$ gcc --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 6.0 (clang-600.0.57) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin15.5.0
Thread model: posix
```

MacOS info:

``` bash
$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.11.5
BuildVersion:   15F34
```
## Solution

I modified the code in input.c to suppress the warnings. Also, checked to see if I can still generate my solution for CS6300 Spring '16 Category Partition assignment, and it worked. 
