### PR TITLE
remove a free() on auto-generated output filename

### DIFF
--- a/MacOSX/main.c
+++ b/MacOSX/main.c
@@ -86,7 +86,6 @@ int main( int argc, char* argv[] )
         strcpy( filename, in_file );
         strcat( filename, ".tsl" );
         out_file = filename;
-        free(filename);
     }
     parse_file();
 


### PR DESCRIPTION
(which caused a segmentation fault)
(this is twong62 from gatech omscs fall 2022)
(this change is for Mac only; if you approve then I can do the same change to the other editions.)