### PR TITLE
Standardize help commands and terminology for improved usability

### DIFF
--- a/Linux/main.c
+++ b/Linux/main.c
@@ -24,7 +24,7 @@ int main_vars_size = sizeof( cats ) + sizeof( props ) + sizeof( short ) * 3 + si
 
 /* local functions */
 Flag parse_args( int num_args, char* args[] );
-void print_man( char* prog_name );
+void print_help( char* prog_name );
 int  cleanup( void );
 int  free_expr( Expression* expr );
 
@@ -57,7 +57,7 @@ int main( int argc, char* argv[] )
 
     if ( argc == 1 )
     {
-        printf( "\nUSAGE:  %s [ --manpage ] [ -cs ] input_file [ -o output_file ]\n\n", argv[0] );
+        printf( "\nUSAGE:  %s [ -h/--help ] [ -cs ] input_file [ -o output_file ]\n\n", argv[0] );
         return EXIT_SUCCESS;
     }
     else
@@ -129,9 +129,9 @@ Flag parse_args( int num_args, char* args[] )
     
     for ( i = 1; i < num_args; i++ )
     {
-        if ( strcmp( args[i], "--manpage" ) == 0 )
+        if ( (strcmp( args[i], "--help" ) == 0) || (strcmp( args[i], "-h" ) == 0) )
         {
-            print_man( args[0] );
+            print_help( args[0] );
             exit( EXIT_SUCCESS );
         }
         
@@ -162,18 +162,18 @@ Flag parse_args( int num_args, char* args[] )
 }
 
 
-/* Print the tsl manpage */
-void print_man( char* prog_name )
+/* Print the tsl help page */
+void print_help( char* prog_name )
 {
     printf( "\nNAME\n\ttsl - generate test frames from a specification file\n" );
-    printf( "\nSYNOPSIS\n\ttsl [ --manpage ] [ -cs ] input_file [ -o output_file ]\n" );
+    printf( "\nSYNOPSIS\n\ttsl [ -h/--help ] [ -cs ] input_file [ -o output_file ]\n" );
     printf( "\nDESCRIPTION\n\tThe TSL utility generates test frames from a specification file\n" );
     printf( "\twritten in the extended Test Specification Language.  By default\n" );
     printf( "\tit writes the test frames to a new file created by appending a\n" );
     printf( "\t'.tsl' extension to the input_file's name.  Options can be used\n" );
     printf( "\tto modify the output.\n" );
     printf( "\nOPTIONS\n\tThe following options are supported:\n" );
-    printf( "\n\t--manpage\n\t\tPrint this man page.\n" );
+    printf( "\n\t-h/--help \n\t\tPrint this help page.\n" );
     printf( "\n\t-c\tReport the number of test frames generated, but don't\n" );
     printf( "\t\twrite them to the output. After the number of frames is\n" );
     printf( "\t\treported you will be given the option of writing them\n" );

--- a/MacOSX/main.c
+++ b/MacOSX/main.c
@@ -24,7 +24,7 @@ int main_vars_size = sizeof( cats ) + sizeof( props ) + sizeof( short ) * 3 + si
 
 /* local functions */
 Flag parse_args( int num_args, char* args[] );
-void print_man( char* prog_name );
+void print_help( char* prog_name );
 int  cleanup( void );
 int  free_expr( Expression* expr );
 
@@ -57,7 +57,7 @@ int main( int argc, char* argv[] )
 
     if ( argc == 1 )
     {
-        printf( "\nUSAGE:  %s [ --manpage ] [ -cs ] input_file [ -o output_file ]\n\n", argv[0] );
+        printf( "\nUSAGE:  %s [ -h/--help ] [ -cs ] input_file [ -o output_file ]\n\n", argv[0] );
         return EXIT_SUCCESS;
     }
     else
@@ -128,9 +128,9 @@ Flag parse_args( int num_args, char* args[] )
     
     for ( i = 1; i < num_args; i++ )
     {
-        if ( strcmp( args[i], "--manpage" ) == 0 )
+        if ( (strcmp( args[i], "--help" ) == 0) || (strcmp( args[i], "-h" ) == 0) )
         {
-            print_man( args[0] );
+            print_help( args[0] );
             exit( EXIT_SUCCESS );
         }
         
@@ -162,18 +162,18 @@ Flag parse_args( int num_args, char* args[] )
 }
 
 
-/* Print the tsl manpage */
-void print_man( char* prog_name )
+/* Print the tsl help page */
+void print_help( char* prog_name )
 {
     printf( "\nNAME\n\ttsl - generate test frames from a specification file\n" );
-    printf( "\nSYNOPSIS\n\ttsl [ --manpage ] [ -cs ] input_file [ -o output_file ]\n" );
+    printf( "\nSYNOPSIS\n\ttsl [ -h/--help ] [ -cs ] input_file [ -o output_file ]\n" );
     printf( "\nDESCRIPTION\n\tThe TSL utility generates test frames from a specification file\n" );
     printf( "\twritten in the extended Test Specification Language.  By default\n" );
     printf( "\tit writes the test frames to a new file created by appending a\n" );
     printf( "\t'.tsl' extension to the input_file's name.  Options can be used\n" );
     printf( "\tto modify the output.\n" );
     printf( "\nOPTIONS\n\tThe following options are supported:\n" );
-    printf( "\n\t--manpage\n\t\tPrint this man page.\n" );
+    printf( "\n\t-h/--help \n\t\tPrint this help page.\n" );
     printf( "\n\t-c\tReport the number of test frames generated, but don't\n" );
     printf( "\t\twrite them to the output. After the number of frames is\n" );
     printf( "\t\treported you will be given the option of writing them\n" );

--- a/Win32/main.c
+++ b/Win32/main.c
@@ -24,7 +24,7 @@ int main_vars_size = sizeof( cats ) + sizeof( props ) + sizeof( short ) * 3 + si
 
 /* local functions */
 Flag parse_args( int num_args, char* args[] );
-void print_man( char* prog_name );
+void print_help( char* prog_name );
 int  cleanup( void );
 int  free_expr( Expression* expr );
 
@@ -57,7 +57,7 @@ int main( int argc, char* argv[] )
 
     if ( argc == 1 )
     {
-        printf( "\nUSAGE:  %s [ --manpage ] [ -cs ] input_file [ -o output_file ]\n\n", argv[0] );
+        printf( "\nUSAGE:  %s [ -h/--help ] [ -cs ] input_file [ -o output_file ]\n\n", argv[0] );
         return EXIT_SUCCESS;
     }
     else
@@ -129,9 +129,9 @@ Flag parse_args( int num_args, char* args[] )
     
     for ( i = 1; i < num_args; i++ )
     {
-        if ( strcmp( args[i], "--manpage" ) == 0 )
+        if ( (strcmp( args[i], "--help" ) == 0) || (strcmp( args[i], "-h" ) == 0) )
         {
-            print_man( args[0] );
+            print_help( args[0] );
             exit( EXIT_SUCCESS );
         }
         
@@ -162,18 +162,18 @@ Flag parse_args( int num_args, char* args[] )
 }
 
 
-/* Print the tsl manpage */
-void print_man( char* prog_name )
+/* Print the tsl help page */
+void print_help( char* prog_name )
 {
     printf( "\nNAME\n\ttsl - generate test frames from a specification file\n" );
-    printf( "\nSYNOPSIS\n\ttsl [ --manpage ] [ -cs ] input_file [ -o output_file ]\n" );
+    printf( "\nSYNOPSIS\n\ttsl [ -h/--help ] [ -cs ] input_file [ -o output_file ]\n" );
     printf( "\nDESCRIPTION\n\tThe TSL utility generates test frames from a specification file\n" );
     printf( "\twritten in the extended Test Specification Language.  By default\n" );
     printf( "\tit writes the test frames to a new file created by appending a\n" );
     printf( "\t'.tsl' extension to the input_file's name.  Options can be used\n" );
     printf( "\tto modify the output.\n" );
     printf( "\nOPTIONS\n\tThe following options are supported:\n" );
-    printf( "\n\t--manpage\n\t\tPrint this man page.\n" );
+    printf( "\n\t-h/--help \n\t\tPrint this help page.\n" );
     printf( "\n\t-c\tReport the number of test frames generated, but don't\n" );
     printf( "\t\twrite them to the output. After the number of frames is\n" );
     printf( "\t\treported you will be given the option of writing them\n" );

--- a/Win8/main.c
+++ b/Win8/main.c
@@ -24,7 +24,7 @@ int main_vars_size = sizeof( cats ) + sizeof( props ) + sizeof( short ) * 3 + si
 
 /* local functions */
 Flag parse_args( int num_args, char* args[] );
-void print_man( char* prog_name );
+void print_help( char* prog_name );
 int  cleanup( void );
 int  free_expr( Expression* expr );
 
@@ -57,7 +57,7 @@ int main( int argc, char* argv[] )
 
     if ( argc == 1 )
     {
-        printf( "\nUSAGE:  %s [ --manpage ] [ -cs ] input_file [ -o output_file ]\n\n", argv[0] );
+        printf( "\nUSAGE:  %s [ -h/--help ] [ -cs ] input_file [ -o output_file ]\n\n", argv[0] );
         return EXIT_SUCCESS;
     }
     else
@@ -129,9 +129,9 @@ Flag parse_args( int num_args, char* args[] )
     
     for ( i = 1; i < num_args; i++ )
     {
-        if ( strcmp( args[i], "--manpage" ) == 0 )
+        if ( (strcmp( args[i], "--help" ) == 0) || (strcmp( args[i], "-h" ) == 0) )
         {
-            print_man( args[0] );
+            print_help( args[0] );
             exit( EXIT_SUCCESS );
         }
         
@@ -162,18 +162,18 @@ Flag parse_args( int num_args, char* args[] )
 }
 
 
-/* Print the tsl manpage */
-void print_man( char* prog_name )
+/* Print the tsl help page */
+void print_help( char* prog_name )
 {
     printf( "\nNAME\n\ttsl - generate test frames from a specification file\n" );
-    printf( "\nSYNOPSIS\n\ttsl [ --manpage ] [ -cs ] input_file [ -o output_file ]\n" );
+    printf( "\nSYNOPSIS\n\ttsl [ -h/--help ] [ -cs ] input_file [ -o output_file ]\n" );
     printf( "\nDESCRIPTION\n\tThe TSL utility generates test frames from a specification file\n" );
     printf( "\twritten in the extended Test Specification Language.  By default\n" );
     printf( "\tit writes the test frames to a new file created by appending a\n" );
     printf( "\t'.tsl' extension to the input_file's name.  Options can be used\n" );
     printf( "\tto modify the output.\n" );
     printf( "\nOPTIONS\n\tThe following options are supported:\n" );
-    printf( "\n\t--manpage\n\t\tPrint this man page.\n" );
+    printf( "\n\t-h/--help \n\t\tPrint this help page.\n" );
     printf( "\n\t-c\tReport the number of test frames generated, but don't\n" );
     printf( "\t\twrite them to the output. After the number of frames is\n" );
     printf( "\t\treported you will be given the option of writing them\n" );


### PR DESCRIPTION
# PR: Standardize help commands and terminology for improved usability

## Description
This PR implements the changes proposed in Issue #13 to improve command-line interface consistency. All instances of "manpage" have been replaced with "help page" throughout the codebase, and the non-standard `--manpage` flag has been updated to use the UNIX standard `-h/--help` flags.

This change improves usability by adhering to well-established CLI conventions that users expect. As an additional benefit, it also aligns with inclusive language recommendations in GitHub's [[Community Guidelines](https://docs.github.com/en/site-policy/github-terms/github-community-guidelines#maintaining-a-strong-community)](https://docs.github.com/en/site-policy/github-terms/github-community-guidelines#maintaining-a-strong-community) and the OpenSource Community's [[Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md)](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md).

## Changes
- Replaced 36 instances of "manpage", "print_man", and "man page" in source files
- Changed command-line flag from `--manpage` to standard `-h/--help` options
- Updated function and variable names for consistency (e.g., `print_man()` → `print_help()`)
- Updated documentation to reflect new command-line interface

## Testing
- Linux binaries build correctly
- Verified that new `-h/--help` flags display help correctly
- Confirmed help output refers consistently to "help page" terminology

## Notes for Reviewers
- Please check for any instances I may have missed
- The command-line interface change should be included in the changelog as it affects user interaction
- Please rebuild the binaries necessary to reflect these changes

## Related Issues
Resolves: #13  (Standardize help commands and terminology)